### PR TITLE
Fix: Filters not always being reset.

### DIFF
--- a/src/hooks/use-data-table.tsx
+++ b/src/hooks/use-data-table.tsx
@@ -153,42 +153,45 @@ export function useDataTable<TData, TValue>({
   })
 
   React.useEffect(() => {
+    // Initialize new params
+    const newParamsObject = {
+      page: 1,
+    }
+
+    // Get all values
     for (const column of debouncedSearchableColumnFilters) {
       if (typeof column.value === "string") {
-        router.push(
-          `${pathname}?${createQueryString({
-            page: 1,
-            [column.id]: typeof column.value === "string" ? column.value : null,
-          })}`
-        )
+        Object.assign(newParamsObject, {
+          [column.id]: typeof column.value === "string" ? column.value : null,
+        })
       }
     }
 
+    // Remove deleted values
     for (const key of searchParams.keys()) {
       if (
         searchableColumns.find((column) => column.id === key) &&
         !debouncedSearchableColumnFilters.find((column) => column.id === key)
       ) {
-        router.push(
-          `${pathname}?${createQueryString({
-            page: 1,
-            [key]: null,
-          })}`
-        )
+        Object.assign(newParamsObject, { [key]: null })
       }
     }
+
+    // After cumulate all the changes, push new params
+    router.push(`${pathname}?${createQueryString(newParamsObject)}`)
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [JSON.stringify(debouncedSearchableColumnFilters)])
 
   React.useEffect(() => {
+    // Initialize new params
+    const newParamsObject = {
+      page: 1,
+    }
+
     for (const column of filterableColumnFilters) {
       if (typeof column.value === "object" && Array.isArray(column.value)) {
-        router.push(
-          `${pathname}?${createQueryString({
-            page: 1,
-            [column.id]: column.value.join("."),
-          })}`
-        )
+        Object.assign(newParamsObject, { [column.id]: column.value.join(".") })
       }
     }
 
@@ -197,14 +200,13 @@ export function useDataTable<TData, TValue>({
         filterableColumns.find((column) => column.id === key) &&
         !filterableColumnFilters.find((column) => column.id === key)
       ) {
-        router.push(
-          `${pathname}?${createQueryString({
-            page: 1,
-            [key]: null,
-          })}`
-        )
+        Object.assign(newParamsObject, { [key]: null })
       }
     }
+
+    // After cumulate all the changes, push new params
+    router.push(`${pathname}?${createQueryString(newParamsObject)}`)
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [JSON.stringify(filterableColumnFilters)])
 


### PR DESCRIPTION
Issue #7 .

From what I understand, the code doesn't clear all the filter because the code tries to loop a `router.push()` which I don't think it's working and thus from what I observe, it only deletes the last filter search params.

What I did is instead of loop `router.push()`, first I collect all of the params, second then remove all the null params, then finally create a `createQueryString` based on the net params then push to the new URL. I also left a comment on my changes that describes this.

I'm really sorry I can't create an exact deployment example of this repo because this repo uses Planet Scale with Drizzle ORM. Last time I used Planet Scale I can create new projects without credit cards, but now it forces me use credit card. So I can't create a Planet Scale project.

But I have created a project implementing SSR table without the search input filter, but a plus with a Date Range Picker. My project link [https://astro.dewodt.com](https://astro.dewodt.com) or github [https://github.com/dewodt/guess-astro](https://github.com/dewodt/guess-astro) (I use Neon Posgres for this project). Particularly, the feature is implemented in the `/history` page. But it requires sign in, so I'm just going to show you a recording of it. Here's the video demo:


https://github.com/sadmann7/shadcn-table/assets/99950492/45e18e1d-5553-44e3-a9c7-b105494a5194


Please review my code. Thank you.
@sadmann7 @kavinvalli 