### PR TITLE
fix:added debounce to pagination to decrease the number of server req…

### DIFF
--- a/src/hooks/use-data-table.tsx
+++ b/src/hooks/use-data-table.tsx
@@ -147,6 +147,11 @@ export function useDataTable<TData, TValue>({
       pageSize: perPage,
     })
 
+  const { pageIndex: debouncedPI, pageSize: debouncedPS } = useDebounce({
+    pageIndex,
+    pageSize,
+  })
+
   const pagination = React.useMemo(
     () => ({
       pageIndex,
@@ -165,8 +170,8 @@ export function useDataTable<TData, TValue>({
   React.useEffect(() => {
     router.push(
       `${pathname}?${createQueryString({
-        page: pageIndex + 1,
-        per_page: pageSize,
+        page: debouncedPI + 1,
+        per_page: debouncedPS,
       })}`,
       {
         scroll: false,
@@ -174,7 +179,7 @@ export function useDataTable<TData, TValue>({
     )
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pageIndex, pageSize])
+  }, [debouncedPI, debouncedPI])
 
   // Handle server-side sorting
   const [sorting, setSorting] = React.useState<SortingState>([

--- a/src/hooks/use-data-table.tsx
+++ b/src/hooks/use-data-table.tsx
@@ -147,10 +147,13 @@ export function useDataTable<TData, TValue>({
       pageSize: perPage,
     })
 
-  const { pageIndex: debouncedPI, pageSize: debouncedPS } = useDebounce({
-    pageIndex,
-    pageSize,
-  })
+  const debouncedPage = React.useMemo(
+    () => ({ pageIndex, pageSize }),
+    [pageIndex, pageSize]
+  )
+
+  const { pageIndex: debouncedPI, pageSize: debouncedPS } =
+    useDebounce(debouncedPage)
 
   const pagination = React.useMemo(
     () => ({


### PR DESCRIPTION
I added a debounce feature to the next page functionality. This prevents multiple quick requests when a user quickly navigates from Page X to Page Y ( Y > X + K , eg : page 1 to 4)  by tapping on the "next" button.

Thanks for creating this library. I have used it in one of my projects and the experience was awesome. I had noticed this issue while working on my project, adding debounce has fixed it. So I am also raising pr for the same here