### PR TITLE
Add selected operator to useEffect in DataTableFilterItem

### DIFF
--- a/src/components/data-table/advanced/data-table-filter-item.tsx
+++ b/src/components/data-table/advanced/data-table-filter-item.tsx
@@ -112,7 +112,7 @@ export function DataTableFilterItem<TData>({
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedOption, debounceValue])
+  }, [selectedOption, debounceValue, selectedOperator])
 
   return (
     <Popover open={open} onOpenChange={setOpen}>


### PR DESCRIPTION
This pull request adds the selectedOperator dependency to the useEffect hook in the DataTableFilterItem component. This ensures that always when we chage the operator of that filter, it will reflect and fetch new data.

The previous behaviour was very not user friendly and this helps make the table feel more responsive!