### PR TITLE
Improve pagination accessibility when floating bar is on

### DIFF
--- a/src/app/_components/tasks-table-floating-bar.tsx
+++ b/src/app/_components/tasks-table-floating-bar.tsx
@@ -55,7 +55,7 @@ export function TasksTableFloatingBar({ table }: TasksTableFloatingBarProps) {
   }, [table])
 
   return (
-    <div className="fixed inset-x-0 bottom-4 z-50 w-full px-4">
+    <div className="fixed inset-x-0 bottom-4 z-50 mx-auto w-fit px-4">
       <div className="w-full overflow-x-auto">
         <div className="mx-auto flex w-fit items-center gap-2 rounded-md border bg-card p-2 shadow-2xl">
           <div className="flex h-7 items-center rounded-md border border-dashed pl-2.5 pr-1">


### PR DESCRIPTION
This PR improves accessibility of the pagination buttons when the floating bar is enabled.

If you tried to click on left or right page arrows of the pagination component, it would not work, because the div of the floating bar was covering it. By removing 'w-full', we can make the div only take as much space as it needs.

https://www.loom.com/share/1b73806cbd024dafbbcccf020418a743?sid=a8799ee3-778b-4418-aca8-3c20a67635c2