### PR TITLE
Update use-data-table.ts

### DIFF
--- a/src/hooks/use-data-table.ts
+++ b/src/hooks/use-data-table.ts
@@ -201,20 +201,6 @@ export function useDataTable<TData, TValue>({
     [pageIndex, pageSize]
   )
 
-  React.useEffect(() => {
-    router.push(
-      `${pathname}?${createQueryString({
-        page: pageIndex + 1,
-        per_page: pageSize,
-      })}`,
-      {
-        scroll: false,
-      }
-    )
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pageIndex, pageSize])
-
   // Handle server-side sorting
   const [sorting, setSorting] = React.useState<SortingState>([
     {
@@ -226,14 +212,20 @@ export function useDataTable<TData, TValue>({
   React.useEffect(() => {
     router.push(
       `${pathname}?${createQueryString({
-        page,
+        page: pageIndex + 1,
+        per_page: pageSize,
         sort: sorting[0]?.id
           ? `${sorting[0]?.id}.${sorting[0]?.desc ? "desc" : "asc"}`
           : null,
-      })}`
+      })}`,
+      {
+        scroll: false,
+      }
     )
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sorting])
+  }, [pageIndex, pageSize, sorting])
+
 
   // Handle server-side filtering
   const debouncedSearchableColumnFilters = JSON.parse(


### PR DESCRIPTION
No need to decouple the useEffect of server side sorting with the useEffect that sends `page`, and `per_page`.

Your current implement doesn't send per_page when the table loads. This is necessarily when geting the first page from the server.

`No per_page` in the first run

![image](https://github.com/sadmann7/shadcn-table/assets/1701705/c9c1b29b-7748-4e3f-adbd-6da7113875ea)
