### PR TITLE
fix: update sheet bug on table change. 

### DIFF
--- a/src/app/_components/update-task-sheet.tsx
+++ b/src/app/_components/update-task-sheet.tsx
@@ -56,6 +56,15 @@ export function UpdateTaskSheet({ task, ...props }: UpdateTaskSheetProps) {
     },
   })
 
+  React.useEffect(() => {
+    form.reset({
+      title: task.title ?? "",
+      label: task.label,
+      status: task.status,
+      priority: task.priority,
+    })
+  }, [task, form])
+
   function onSubmit(input: UpdateTaskSchema) {
     startUpdateTransition(async () => {
       const { error } = await updateTask({


### PR DESCRIPTION
fixes issue mentioned in https://github.com/sadmann7/shadcn-table/issues/497 and https://github.com/sadmann7/shadcn-table/issues/475

added useEffect on the [update-task-sheet.tsx](https://github.com/sadmann7/shadcn-table/compare/main...realtydev:fix-update-sheet-issue?expand=1#diff-b5be49420c5bd580eafd2754aaba4da53335399722b19bdd81230b98fc9354ea) to reset the form on task prop changes. 