### PR TITLE
fix: data table filter style overflow

### DIFF
--- a/src/components/data-table/data-table-filter-list.tsx
+++ b/src/components/data-table/data-table-filter-list.tsx
@@ -511,7 +511,7 @@ export function DataTableFilterList<TData>({
             </p>
           </div>
         )}
-        <div className="flex max-h-40 flex-col gap-2 overflow-y-visible pr-1">
+        <div className="flex max-h-40 flex-col gap-2 overflow-y-auto pr-1 py-0.5">
           {filters.map((filter, index) => {
             const filterId = `${id}-filter-${index}`
             const joinOperatorListboxId = `${filterId}-join-operator-listbox`

--- a/src/components/data-table/data-table-filter-list.tsx
+++ b/src/components/data-table/data-table-filter-list.tsx
@@ -511,7 +511,7 @@ export function DataTableFilterList<TData>({
             </p>
           </div>
         )}
-        <div className="flex max-h-40 flex-col gap-2 overflow-y-auto pr-1">
+        <div className="flex max-h-40 flex-col gap-2 overflow-y-visible pr-1">
           {filters.map((filter, index) => {
             const filterId = `${id}-filter-${index}`
             const joinOperatorListboxId = `${filterId}-join-operator-listbox`


### PR DESCRIPTION
Fix #648, hoping this is the good way to solve this display issue.
I don't know the reason why the filter container is currently `overflow-y-auto`.

<img width="610" alt="image" src="https://github.com/user-attachments/assets/8fdb5ed9-8cf7-414b-914f-cd0b27a5db16">


