### PR TITLE
fix: Preserve slider filter values on page refresh (#983)

### DIFF
--- a/src/components/data-table/data-table-slider-filter.tsx
+++ b/src/components/data-table/data-table-slider-filter.tsx
@@ -31,6 +31,21 @@ function getIsValidRange(value: unknown): value is RangeValue {
   );
 }
 
+function parseValuesAsNumbers(value: unknown): RangeValue | undefined {
+  if (
+    Array.isArray(value) &&
+    value.length === 2 &&
+    value.every(
+      (v) =>
+        (typeof v === "string" || typeof v === "number") && !Number.isNaN(v),
+    )
+  ) {
+    return [Number(value[0]), Number(value[1])];
+  }
+
+  return undefined;
+}
+
 interface DataTableSliderFilterProps<TData> {
   column: Column<TData, unknown>;
   title?: string;
@@ -42,9 +57,7 @@ export function DataTableSliderFilter<TData>({
 }: DataTableSliderFilterProps<TData>) {
   const id = React.useId();
 
-  const columnFilterValue = getIsValidRange(column.getFilterValue())
-    ? (column.getFilterValue() as RangeValue)
-    : undefined;
+  const columnFilterValue = parseValuesAsNumbers(column.getFilterValue());
 
   const defaultRange = column.columnDef.meta?.range;
   const unit = column.columnDef.meta?.unit;


### PR DESCRIPTION
Fixes #983 

I this PR modifies slider filter component, to correctly handle initial values passed from `column.getFilterValue()`