### PR TITLE
fix:fixed visual bug with the checkbox in zen browser

### DIFF
--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -19,12 +19,14 @@ function Checkbox({
       )}
       {...props}
     >
+
       <CheckboxPrimitive.Indicator
         data-slot="checkbox-indicator"
-        className="flex items-center justify-center text-current transition-none"
+        className="flex items-center justify-center text-current transition-none h-full w-full"
       >
         <CheckIcon className="size-3.5" />
       </CheckboxPrimitive.Indicator>
+ 
     </CheckboxPrimitive.Root>
   );
 }


### PR DESCRIPTION
## Description

I found a visual bug when I was testing in zen:

<img width="1915" height="1022" alt="image" src="https://github.com/user-attachments/assets/9e5f1e8b-a2b3-4fb0-9027-55b9272e0ddf" />

I resolve it giving the checkboxPrimitive `h-full` and `w-full`