### PR TITLE
chore: fix toolbar data value not updated when revalidateTag/Path

### DIFF
--- a/src/components/data-table/data-table-toolbar.tsx
+++ b/src/components/data-table/data-table-toolbar.tsx
@@ -24,10 +24,7 @@ export function DataTableToolbar<TData>({
 }: DataTableToolbarProps<TData>) {
   const isFiltered = table.getState().columnFilters.length > 0;
 
-  const columns = React.useMemo(
-    () => table.getAllColumns().filter((column) => column.getCanFilter()),
-    [table],
-  );
+  const columns = table.getAllColumns().filter((column) => column.getCanFilter())
 
   const onReset = React.useCallback(() => {
     table.resetColumnFilters();


### PR DESCRIPTION
This change ensures that the toolbar data is refreshed whenever revalidateTag or revalidatePath is triggered.
