### PR TITLE
feat: add locales parameter to formatDate for internationalization su…

### DIFF
--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,11 +1,12 @@
 export function formatDate(
   date: Date | string | number | undefined,
   opts: Intl.DateTimeFormatOptions = {},
+  locales?: string | string[]
 ) {
   if (!date) return "";
 
   try {
-    return new Intl.DateTimeFormat("en-US", {
+    return new Intl.DateTimeFormat(locales ?? "en-US", {
       month: opts.month ?? "long",
       day: opts.day ?? "numeric",
       year: opts.year ?? "numeric",


### PR DESCRIPTION
// Before (only en-US)
formatDate(new Date(), { year: 'numeric', month: 'long', day: 'numeric' });
// → "December 19, 2025"

// After – custom locale
formatDate(new Date(), { year: 'numeric', month: 'long', day: 'numeric' }, 'fr-FR');
// → "19 décembre 2025"

formatDate(new Date(), { day: '2-digit', month: '2-digit', year: 'numeric' }, 'de-DE');
// → "19.12.2025"

formatDate(new Date(), { year: 'numeric', month: 'long', day: 'numeric' }, 'zh-CN');
// → "2025年12月19日"