### PR TITLE
feat(data-grid): add `columnFilterOperators` to specify operators

### DIFF
--- a/src/types/data-grid.ts
+++ b/src/types/data-grid.ts
@@ -60,6 +60,7 @@ declare module "@tanstack/react-table" {
   interface ColumnMeta<TData extends RowData, TValue> {
     label?: string;
     cell?: CellOpts;
+    filterOperators?: FilterOperator[];
   }
 
   // biome-ignore lint/correctness/noUnusedVariables: TData is used in the TableMeta interface


### PR DESCRIPTION
specify operators in each column as:

```
        meta: {
          label: "Age",
          cell: { variant: "number" },
          filterOperators: [
            // I can now show only operators supported by my API
            "equals",
            "lessThan",
            "greaterThan",
          ],
        },
```