### PR TITLE
feat(data-table): row drag-and-drop reordering for tasks table

### DIFF
--- a/src/app/components/tasks-table-columns.tsx
+++ b/src/app/components/tasks-table-columns.tsx
@@ -12,6 +12,7 @@ import {
 import * as React from "react";
 import { toast } from "sonner";
 import { DataTableColumnHeader } from "@/components/data-table/data-table-column-header";
+import { DataTableDragHandle } from "@/components/data-table/data-table-drag-handle";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -31,10 +32,8 @@ import { type Task, tasks } from "@/db/schema";
 import { formatDate } from "@/lib/format";
 import { getErrorMessage } from "@/lib/handle-error";
 import type { DataTableRowAction } from "@/types/data-table";
-
 import { updateTask } from "../lib/actions";
 import { getPriorityIcon, getStatusIcon } from "../lib/utils";
-import { DataTableDragHandle } from "@/components/data-table/data-table-drag-handle";
 
 interface GetTasksTableColumnsProps {
   statusCounts: Record<Task["status"], number>;
@@ -53,9 +52,9 @@ export function getTasksTableColumns({
 }: GetTasksTableColumnsProps): ColumnDef<Task>[] {
   return [
     {
-      id: 'drag',
+      id: "drag",
       header: () => null,
-      cell: ({ row }) => <DataTableDragHandle label="Drag to reorder" />,
+      cell: () => <DataTableDragHandle label="Drag to reorder" />,
       size: 36,
       enableSorting: false,
       enableHiding: false,

--- a/src/app/components/tasks-table-columns.tsx
+++ b/src/app/components/tasks-table-columns.tsx
@@ -34,6 +34,7 @@ import type { DataTableRowAction } from "@/types/data-table";
 
 import { updateTask } from "../lib/actions";
 import { getPriorityIcon, getStatusIcon } from "../lib/utils";
+import { DataTableDragHandle } from "@/components/data-table/data-table-drag-handle";
 
 interface GetTasksTableColumnsProps {
   statusCounts: Record<Task["status"], number>;
@@ -51,6 +52,14 @@ export function getTasksTableColumns({
   setRowAction,
 }: GetTasksTableColumnsProps): ColumnDef<Task>[] {
   return [
+    {
+      id: 'drag',
+      header: () => null,
+      cell: ({ row }) => <DataTableDragHandle label="Drag to reorder" />,
+      size: 36,
+      enableSorting: false,
+      enableHiding: false,
+    },
     {
       id: "select",
       header: ({ table }) => (

--- a/src/app/components/tasks-table.tsx
+++ b/src/app/components/tasks-table.tsx
@@ -21,6 +21,7 @@ import { useFeatureFlags } from "./feature-flags-provider";
 import { TasksTableActionBar } from "./tasks-table-action-bar";
 import { getTasksTableColumns } from "./tasks-table-columns";
 import { UpdateTaskSheet } from "./update-task-sheet";
+import { toast } from "sonner";
 
 interface TasksTableProps {
   promises: Promise<
@@ -44,6 +45,19 @@ export function TasksTable({ promises, queryKeys }: TasksTableProps) {
     estimatedHoursRange,
   ] = React.use(promises);
 
+  const dataOrderKey = React.useMemo(
+    () => data.map((row) => row.id).join(),
+    [data],
+  );
+
+  const [orderOverride, setOrderOverride] = React.useState<Task[] | null>(null);
+
+  React.useEffect(() => {
+    setOrderOverride(null);
+  }, [dataOrderKey]);
+
+  const tableData = orderOverride ?? data;
+
   const [rowAction, setRowAction] =
     React.useState<DataTableRowAction<Task> | null>(null);
 
@@ -59,7 +73,7 @@ export function TasksTable({ promises, queryKeys }: TasksTableProps) {
   );
 
   const { table, shallow, debounceMs, throttleMs } = useDataTable({
-    data,
+    data: tableData,
     columns,
     pageCount,
     enableAdvancedFilter,
@@ -73,11 +87,26 @@ export function TasksTable({ promises, queryKeys }: TasksTableProps) {
     clearOnDefault: true,
   });
 
+  const onRowReorder = React.useCallback((orderedRowIds: string[]) => {
+    setOrderOverride((prev) => {
+      const source = prev ?? data;
+      const rowMap = new Map(source.map((row) => [String(row.id), row]));
+      const next = orderedRowIds
+        .map((id) => rowMap.get(id))
+        .filter((row): row is Task => row !== undefined);
+      if (next.length !== source.length) return prev;
+      return next;
+    });
+    toast.success("Rows reordered successfully");
+  }, [data]);
+
   return (
     <>
       <DataTable
         table={table}
         actionBar={<TasksTableActionBar table={table} />}
+        enableRowDragAndDrop={true}
+        onRowReorder={onRowReorder}
       >
         {enableAdvancedFilter ? (
           <DataTableAdvancedToolbar table={table}>

--- a/src/app/components/tasks-table.tsx
+++ b/src/app/components/tasks-table.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as React from "react";
+import { toast } from "sonner";
 import { DataTable } from "@/components/data-table/data-table";
 import { DataTableAdvancedToolbar } from "@/components/data-table/data-table-advanced-toolbar";
 import { DataTableFilterList } from "@/components/data-table/data-table-filter-list";
@@ -21,7 +22,6 @@ import { useFeatureFlags } from "./feature-flags-provider";
 import { TasksTableActionBar } from "./tasks-table-action-bar";
 import { getTasksTableColumns } from "./tasks-table-columns";
 import { UpdateTaskSheet } from "./update-task-sheet";
-import { toast } from "sonner";
 
 interface TasksTableProps {
   promises: Promise<
@@ -45,16 +45,7 @@ export function TasksTable({ promises, queryKeys }: TasksTableProps) {
     estimatedHoursRange,
   ] = React.use(promises);
 
-  const dataOrderKey = React.useMemo(
-    () => data.map((row) => row.id).join(),
-    [data],
-  );
-
   const [orderOverride, setOrderOverride] = React.useState<Task[] | null>(null);
-
-  React.useEffect(() => {
-    setOrderOverride(null);
-  }, [dataOrderKey]);
 
   const tableData = orderOverride ?? data;
 
@@ -87,18 +78,21 @@ export function TasksTable({ promises, queryKeys }: TasksTableProps) {
     clearOnDefault: true,
   });
 
-  const onRowReorder = React.useCallback((orderedRowIds: string[]) => {
-    setOrderOverride((prev) => {
-      const source = prev ?? data;
-      const rowMap = new Map(source.map((row) => [String(row.id), row]));
-      const next = orderedRowIds
-        .map((id) => rowMap.get(id))
-        .filter((row): row is Task => row !== undefined);
-      if (next.length !== source.length) return prev;
-      return next;
-    });
-    toast.success("Rows reordered successfully");
-  }, [data]);
+  const onRowReorder = React.useCallback(
+    (orderedRowIds: string[]) => {
+      setOrderOverride((prev) => {
+        const source = prev ?? data;
+        const rowMap = new Map(source.map((row) => [String(row.id), row]));
+        const next = orderedRowIds
+          .map((id) => rowMap.get(id))
+          .filter((row): row is Task => row !== undefined);
+        if (next.length !== source.length) return prev;
+        return next;
+      });
+      toast.success("Rows reordered successfully");
+    },
+    [data],
+  );
 
   return (
     <>

--- a/src/components/data-table/data-table-drag-handle.tsx
+++ b/src/components/data-table/data-table-drag-handle.tsx
@@ -1,19 +1,21 @@
-'use client'
-
-import * as React from 'react'
-import { GripVertical } from 'lucide-react'
+"use client";
 
 import type {
   DraggableAttributes,
   DraggableSyntheticListeners,
-} from "@dnd-kit/core"
+} from "@dnd-kit/core";
+import { GripVertical } from "lucide-react";
+import * as React from "react";
 
-import { Button } from '@/components/ui/button'
-import { cn } from '@/lib/utils'
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
-export type DataTableDragHandleProps = Omit<React.ComponentProps<typeof Button>, 'onClick'> & {
-  label?: string
-}
+export type DataTableDragHandleProps = Omit<
+  React.ComponentProps<typeof Button>,
+  "onClick"
+> & {
+  label?: string;
+};
 
 /**
  * Internal context provided by `<DataTable>` to each sortable row.
@@ -23,16 +25,15 @@ export type DataTableDragHandleProps = Omit<React.ComponentProps<typeof Button>,
  * are wired automatically.
  */
 interface RowDragHandleContextValue {
-  attributes: DraggableAttributes
-  listeners: DraggableSyntheticListeners
-  isDragging: boolean
+  attributes: DraggableAttributes;
+  listeners: DraggableSyntheticListeners;
+  isDragging: boolean;
   /** Disabled when the row is not part of the sortable context. */
-  enabled: boolean
+  enabled: boolean;
 }
 
 const RowDragHandleContext =
-  React.createContext<RowDragHandleContextValue | null>(null)
-
+  React.createContext<RowDragHandleContextValue | null>(null);
 
 /**
  * Renders a drag handle bound to the surrounding sortable row.
@@ -43,24 +44,24 @@ const RowDragHandleContext =
  */
 function DataTableDragHandle({
   className,
-  label = 'Drag to reorder',
+  label = "Drag to reorder",
   children,
   ...props
 }: DataTableDragHandleProps) {
-  const ctx = React.useContext(RowDragHandleContext)
+  const ctx = React.useContext(RowDragHandleContext);
 
   if (!ctx?.enabled) {
     return (
       <span
         aria-hidden
         className={cn(
-          'inline-flex size-7 items-center justify-center text-muted-foreground/40',
+          "inline-flex size-7 items-center justify-center text-muted-foreground/40",
           className,
         )}
       >
         {children ?? <GripVertical className="size-4" />}
       </span>
-    )
+    );
   }
 
   return (
@@ -71,7 +72,7 @@ function DataTableDragHandle({
       aria-label={label}
       data-dragging={ctx.isDragging || undefined}
       className={cn(
-        'size-7 cursor-grab text-muted-foreground hover:bg-muted/60 active:cursor-grabbing data-dragging:cursor-grabbing',
+        "size-7 cursor-grab text-muted-foreground hover:bg-muted/60 active:cursor-grabbing data-dragging:cursor-grabbing",
         className,
       )}
       {...ctx.attributes}
@@ -80,10 +81,7 @@ function DataTableDragHandle({
     >
       {children ?? <GripVertical className="size-4" />}
     </Button>
-  )
+  );
 }
 
-export {
-  DataTableDragHandle,
-  RowDragHandleContext,
-}
+export { DataTableDragHandle, RowDragHandleContext };

--- a/src/components/data-table/data-table-drag-handle.tsx
+++ b/src/components/data-table/data-table-drag-handle.tsx
@@ -1,0 +1,89 @@
+'use client'
+
+import * as React from 'react'
+import { GripVertical } from 'lucide-react'
+
+import type {
+  DraggableAttributes,
+  DraggableSyntheticListeners,
+} from "@dnd-kit/core"
+
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+export type DataTableDragHandleProps = Omit<React.ComponentProps<typeof Button>, 'onClick'> & {
+  label?: string
+}
+
+/**
+ * Internal context provided by `<DataTable>` to each sortable row.
+ *
+ * Keeps the drag handle decoupled from the row implementation: the consumer
+ * just renders `<DataTableDragHandle />` inside any cell and the listeners
+ * are wired automatically.
+ */
+interface RowDragHandleContextValue {
+  attributes: DraggableAttributes
+  listeners: DraggableSyntheticListeners
+  isDragging: boolean
+  /** Disabled when the row is not part of the sortable context. */
+  enabled: boolean
+}
+
+const RowDragHandleContext =
+  React.createContext<RowDragHandleContextValue | null>(null)
+
+
+/**
+ * Renders a drag handle bound to the surrounding sortable row.
+ *
+ * Falls back to a static visual placeholder when used outside a DnD-enabled
+ * `<DataTable>` (e.g. during SSR / first paint). This keeps the cell layout
+ * stable across hydration — `@dnd-kit` only registers listeners on the client.
+ */
+function DataTableDragHandle({
+  className,
+  label = 'Drag to reorder',
+  children,
+  ...props
+}: DataTableDragHandleProps) {
+  const ctx = React.useContext(RowDragHandleContext)
+
+  if (!ctx?.enabled) {
+    return (
+      <span
+        aria-hidden
+        className={cn(
+          'inline-flex size-7 items-center justify-center text-muted-foreground/40',
+          className,
+        )}
+      >
+        {children ?? <GripVertical className="size-4" />}
+      </span>
+    )
+  }
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon"
+      aria-label={label}
+      data-dragging={ctx.isDragging || undefined}
+      className={cn(
+        'size-7 cursor-grab text-muted-foreground hover:bg-muted/60 active:cursor-grabbing data-dragging:cursor-grabbing',
+        className,
+      )}
+      {...ctx.attributes}
+      {...ctx.listeners}
+      {...props}
+    >
+      {children ?? <GripVertical className="size-4" />}
+    </Button>
+  )
+}
+
+export {
+  DataTableDragHandle,
+  RowDragHandleContext,
+}

--- a/src/components/data-table/data-table-sortable-row.tsx
+++ b/src/components/data-table/data-table-sortable-row.tsx
@@ -1,46 +1,54 @@
 import { useSortable } from "@dnd-kit/sortable";
-import { RowDragHandleContext } from "./data-table-drag-handle";
-import { CSS } from '@dnd-kit/utilities'
+import { CSS } from "@dnd-kit/utilities";
+import { flexRender, type Row } from "@tanstack/react-table";
 import { useMemo } from "react";
-import { TableCell, TableRow } from "../ui/table";
 import { getColumnPinningStyle } from "@/lib/data-table";
-import { flexRender, Row } from "@tanstack/react-table";
+import { TableCell, TableRow } from "../ui/table";
+import { RowDragHandleContext } from "./data-table-drag-handle";
 
 export function SortableRow<TData>({ row }: { row: Row<TData> }) {
-    const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
-      id: row.id,
-    })
-  
-    const style: React.CSSProperties = {
-      transform: CSS.Transform.toString(transform),
-      transition,
-      opacity: isDragging ? 0.6 : undefined,
-      position: 'relative',
-      zIndex: isDragging ? 1 : undefined,
-    }
-  
-    const dragCtx = useMemo(
-      () => ({ attributes, listeners, isDragging, enabled: true }),
-      [attributes, listeners, isDragging],
-    )
-  
-    return (
-      <RowDragHandleContext.Provider value={dragCtx}>
-        <TableRow
-          ref={setNodeRef}
-          data-state={row.getIsSelected() && 'selected'}
-          data-dragging={isDragging || undefined}
-          style={style}
-          className="data-dragging:bg-muted/40"
-        >
-          {row.getVisibleCells().map((cell) => (
-            <TableCell key={cell.id} style={{ ...getColumnPinningStyle({ column: cell.column }) }}>
-              {flexRender(cell.column.columnDef.cell, cell.getContext())}
-            </TableCell>
-          ))}
-        </TableRow>
-      </RowDragHandleContext.Provider>
-    )
-  }
-  
-  
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({
+    id: row.id,
+  });
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.6 : undefined,
+    position: "relative",
+    zIndex: isDragging ? 1 : undefined,
+  };
+
+  const dragCtx = useMemo(
+    () => ({ attributes, listeners, isDragging, enabled: true }),
+    [attributes, listeners, isDragging],
+  );
+
+  return (
+    <RowDragHandleContext.Provider value={dragCtx}>
+      <TableRow
+        ref={setNodeRef}
+        data-state={row.getIsSelected() && "selected"}
+        data-dragging={isDragging || undefined}
+        style={style}
+        className="data-dragging:bg-muted/40"
+      >
+        {row.getVisibleCells().map((cell) => (
+          <TableCell
+            key={cell.id}
+            style={{ ...getColumnPinningStyle({ column: cell.column }) }}
+          >
+            {flexRender(cell.column.columnDef.cell, cell.getContext())}
+          </TableCell>
+        ))}
+      </TableRow>
+    </RowDragHandleContext.Provider>
+  );
+}

--- a/src/components/data-table/data-table-sortable-row.tsx
+++ b/src/components/data-table/data-table-sortable-row.tsx
@@ -1,0 +1,46 @@
+import { useSortable } from "@dnd-kit/sortable";
+import { RowDragHandleContext } from "./data-table-drag-handle";
+import { CSS } from '@dnd-kit/utilities'
+import { useMemo } from "react";
+import { TableCell, TableRow } from "../ui/table";
+import { getColumnPinningStyle } from "@/lib/data-table";
+import { flexRender, Row } from "@tanstack/react-table";
+
+export function SortableRow<TData>({ row }: { row: Row<TData> }) {
+    const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+      id: row.id,
+    })
+  
+    const style: React.CSSProperties = {
+      transform: CSS.Transform.toString(transform),
+      transition,
+      opacity: isDragging ? 0.6 : undefined,
+      position: 'relative',
+      zIndex: isDragging ? 1 : undefined,
+    }
+  
+    const dragCtx = useMemo(
+      () => ({ attributes, listeners, isDragging, enabled: true }),
+      [attributes, listeners, isDragging],
+    )
+  
+    return (
+      <RowDragHandleContext.Provider value={dragCtx}>
+        <TableRow
+          ref={setNodeRef}
+          data-state={row.getIsSelected() && 'selected'}
+          data-dragging={isDragging || undefined}
+          style={style}
+          className="data-dragging:bg-muted/40"
+        >
+          {row.getVisibleCells().map((cell) => (
+            <TableCell key={cell.id} style={{ ...getColumnPinningStyle({ column: cell.column }) }}>
+              {flexRender(cell.column.columnDef.cell, cell.getContext())}
+            </TableCell>
+          ))}
+        </TableRow>
+      </RowDragHandleContext.Provider>
+    )
+  }
+  
+  

--- a/src/components/data-table/data-table.tsx
+++ b/src/components/data-table/data-table.tsx
@@ -1,6 +1,12 @@
-import { flexRender, type Table as TanstackTable } from "@tanstack/react-table";
+import { flexRender, Row, type Table as TanstackTable } from "@tanstack/react-table";
 import type * as React from "react";
 
+
+import { DndContext, type Modifier } from '@dnd-kit/core'
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable'
 import { DataTablePagination } from "@/components/data-table/data-table-pagination";
 import {
   Table,
@@ -12,10 +18,15 @@ import {
 } from "@/components/ui/table";
 import { getColumnPinningStyle } from "@/lib/data-table";
 import { cn } from "@/lib/utils";
+import { useDataTableRowDnd } from "@/hooks/use-data-table-row-dnd";
+import { SortableRow } from "./data-table-sortable-row";
 
 interface DataTableProps<TData> extends React.ComponentProps<"div"> {
   table: TanstackTable<TData>;
   actionBar?: React.ReactNode;
+  enableRowDragAndDrop?: boolean;
+  onRowReorder?: (orderedRowIds: string[]) => void;
+  dragModifiers?: Modifier[];
 }
 
 export function DataTable<TData>({
@@ -23,79 +34,95 @@ export function DataTable<TData>({
   actionBar,
   children,
   className,
+  enableRowDragAndDrop = false,
+  onRowReorder,
+  dragModifiers,
   ...props
 }: DataTableProps<TData>) {
-  return (
-    <div
-      className={cn("flex w-full flex-col gap-2.5 overflow-auto", className)}
-      {...props}
-    >
-      {children}
-      <div className="overflow-hidden rounded-md border">
-        <Table>
-          <TableHeader>
-            {table.getHeaderGroups().map((headerGroup) => (
-              <TableRow key={headerGroup.id}>
-                {headerGroup.headers.map((header) => (
-                  <TableHead
-                    key={header.id}
-                    colSpan={header.colSpan}
-                    style={{
-                      ...getColumnPinningStyle({ column: header.column }),
-                    }}
+
+  const rows = table.getRowModel().rows;
+
+  const dnd = useDataTableRowDnd({
+    rows,
+    enabled: enableRowDragAndDrop,
+    onRowReorder,
+    modifiers: dragModifiers,
+  })
+
+  const tableMarkup = (
+    <Table>
+      <TableHeader>
+        {table.getHeaderGroups().map((headerGroup) => (
+          <TableRow key={headerGroup.id}>
+            {headerGroup.headers.map((header) => (
+              <TableHead
+                key={header.id}
+                colSpan={header.colSpan}
+                style={{ ...getColumnPinningStyle({ column: header.column }) }}
+              >
+                {header.isPlaceholder
+                  ? null
+                  : flexRender(header.column.columnDef.header, header.getContext())}
+              </TableHead>
+            ))}
+          </TableRow>
+        ))}
+      </TableHeader>
+      <TableBody>
+        {rows?.length ? (
+          rows.map((row) =>
+            dnd.active ? (
+              <SortableRow key={row.id} row={row} />
+            ) : (
+              <TableRow key={row.id} data-state={row.getIsSelected() && 'selected'}>
+                {row.getVisibleCells().map((cell) => (
+                  <TableCell
+                    key={cell.id}
+                    style={{ ...getColumnPinningStyle({ column: cell.column }) }}
                   >
-                    {header.isPlaceholder
-                      ? null
-                      : flexRender(
-                          header.column.columnDef.header,
-                          header.getContext(),
-                        )}
-                  </TableHead>
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </TableCell>
                 ))}
               </TableRow>
-            ))}
-          </TableHeader>
-          <TableBody>
-            {table.getRowModel().rows?.length ? (
-              table.getRowModel().rows.map((row) => (
-                <TableRow
-                  key={row.id}
-                  data-state={row.getIsSelected() && "selected"}
-                >
-                  {row.getVisibleCells().map((cell) => (
-                    <TableCell
-                      key={cell.id}
-                      style={{
-                        ...getColumnPinningStyle({ column: cell.column }),
-                      }}
-                    >
-                      {flexRender(
-                        cell.column.columnDef.cell,
-                        cell.getContext(),
-                      )}
-                    </TableCell>
-                  ))}
-                </TableRow>
-              ))
-            ) : (
-              <TableRow>
+            ),
+          )
+        ) : (
+          <TableRow>
                 <TableCell
                   colSpan={table.getAllColumns().length}
                   className="h-24 text-center"
                 >
                   No results.
                 </TableCell>
-              </TableRow>
-            )}
-          </TableBody>
-        </Table>
+          </TableRow>
+        )}
+      </TableBody>
+    </Table>
+  )
+
+  return (
+    <div className={cn('flex w-full flex-col gap-2.5 overflow-auto', className)} {...props}>
+      {children}
+      <div className="overflow-hidden rounded-md border">
+        {dnd.active ? (
+          <DndContext
+            sensors={dnd.sensors}
+            collisionDetection={dnd.collisionDetection}
+            modifiers={dnd.modifiers}
+            onDragEnd={dnd.handleDragEnd}
+          >
+            <SortableContext items={dnd.rowIds} strategy={verticalListSortingStrategy}>
+              {tableMarkup}
+            </SortableContext>
+          </DndContext>
+        ) : (
+          tableMarkup
+        )}
       </div>
       <div className="flex flex-col gap-2.5">
         <DataTablePagination table={table} />
-        {actionBar &&
-          table.getFilteredSelectedRowModel().rows.length > 0 &&
-          actionBar}
+        {actionBar && table.getFilteredSelectedRowModel().rows.length > 0 && actionBar}
       </div>
     </div>
-  );
+  )
 }

--- a/src/components/data-table/data-table.tsx
+++ b/src/components/data-table/data-table.tsx
@@ -1,12 +1,14 @@
-import { flexRender, Row, type Table as TanstackTable } from "@tanstack/react-table";
-import type * as React from "react";
-
-
-import { DndContext, type Modifier } from '@dnd-kit/core'
+import { DndContext, type Modifier } from "@dnd-kit/core";
 import {
   SortableContext,
   verticalListSortingStrategy,
-} from '@dnd-kit/sortable'
+} from "@dnd-kit/sortable";
+import {
+  flexRender,
+  Row,
+  type Table as TanstackTable,
+} from "@tanstack/react-table";
+import type * as React from "react";
 import { DataTablePagination } from "@/components/data-table/data-table-pagination";
 import {
   Table,
@@ -16,9 +18,9 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { useDataTableRowDnd } from "@/hooks/use-data-table-row-dnd";
 import { getColumnPinningStyle } from "@/lib/data-table";
 import { cn } from "@/lib/utils";
-import { useDataTableRowDnd } from "@/hooks/use-data-table-row-dnd";
 import { SortableRow } from "./data-table-sortable-row";
 
 interface DataTableProps<TData> extends React.ComponentProps<"div"> {
@@ -39,7 +41,6 @@ export function DataTable<TData>({
   dragModifiers,
   ...props
 }: DataTableProps<TData>) {
-
   const rows = table.getRowModel().rows;
 
   const dnd = useDataTableRowDnd({
@@ -47,7 +48,7 @@ export function DataTable<TData>({
     enabled: enableRowDragAndDrop,
     onRowReorder,
     modifiers: dragModifiers,
-  })
+  });
 
   const tableMarkup = (
     <Table>
@@ -62,7 +63,10 @@ export function DataTable<TData>({
               >
                 {header.isPlaceholder
                   ? null
-                  : flexRender(header.column.columnDef.header, header.getContext())}
+                  : flexRender(
+                      header.column.columnDef.header,
+                      header.getContext(),
+                    )}
               </TableHead>
             ))}
           </TableRow>
@@ -74,11 +78,16 @@ export function DataTable<TData>({
             dnd.active ? (
               <SortableRow key={row.id} row={row} />
             ) : (
-              <TableRow key={row.id} data-state={row.getIsSelected() && 'selected'}>
+              <TableRow
+                key={row.id}
+                data-state={row.getIsSelected() && "selected"}
+              >
                 {row.getVisibleCells().map((cell) => (
                   <TableCell
                     key={cell.id}
-                    style={{ ...getColumnPinningStyle({ column: cell.column }) }}
+                    style={{
+                      ...getColumnPinningStyle({ column: cell.column }),
+                    }}
                   >
                     {flexRender(cell.column.columnDef.cell, cell.getContext())}
                   </TableCell>
@@ -88,20 +97,23 @@ export function DataTable<TData>({
           )
         ) : (
           <TableRow>
-                <TableCell
-                  colSpan={table.getAllColumns().length}
-                  className="h-24 text-center"
-                >
-                  No results.
-                </TableCell>
+            <TableCell
+              colSpan={table.getAllColumns().length}
+              className="h-24 text-center"
+            >
+              No results.
+            </TableCell>
           </TableRow>
         )}
       </TableBody>
     </Table>
-  )
+  );
 
   return (
-    <div className={cn('flex w-full flex-col gap-2.5 overflow-auto', className)} {...props}>
+    <div
+      className={cn("flex w-full flex-col gap-2.5 overflow-auto", className)}
+      {...props}
+    >
       {children}
       <div className="overflow-hidden rounded-md border">
         {dnd.active ? (
@@ -111,7 +123,10 @@ export function DataTable<TData>({
             modifiers={dnd.modifiers}
             onDragEnd={dnd.handleDragEnd}
           >
-            <SortableContext items={dnd.rowIds} strategy={verticalListSortingStrategy}>
+            <SortableContext
+              items={dnd.rowIds}
+              strategy={verticalListSortingStrategy}
+            >
               {tableMarkup}
             </SortableContext>
           </DndContext>
@@ -121,8 +136,10 @@ export function DataTable<TData>({
       </div>
       <div className="flex flex-col gap-2.5">
         <DataTablePagination table={table} />
-        {actionBar && table.getFilteredSelectedRowModel().rows.length > 0 && actionBar}
+        {actionBar &&
+          table.getFilteredSelectedRowModel().rows.length > 0 &&
+          actionBar}
       </div>
     </div>
-  )
+  );
 }

--- a/src/hooks/use-data-table-row-dnd.ts
+++ b/src/hooks/use-data-table-row-dnd.ts
@@ -1,0 +1,88 @@
+'use client'
+
+import * as React from 'react'
+import {
+  KeyboardSensor,
+  MouseSensor,
+  TouchSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type CollisionDetection,
+  type DragEndEvent,
+  type Modifier,
+  type SensorDescriptor,
+  type SensorOptions,
+} from '@dnd-kit/core'
+import { restrictToParentElement, restrictToVerticalAxis } from '@dnd-kit/modifiers'
+import { arrayMove, sortableKeyboardCoordinates } from '@dnd-kit/sortable'
+import type { Row } from '@tanstack/react-table'
+import { useMounted } from './use-mounted'
+
+const DEFAULT_DRAG_MODIFIERS: Modifier[] = [restrictToVerticalAxis, restrictToParentElement]
+
+interface UseDataTableRowDndOptions<TData> {
+  rows: Row<TData>[]
+  /** External enable flag (e.g. controlled by a server mutation pending state). */
+  enabled?: boolean
+  /** Called with the new visible-row order after a drop. */
+  onRowReorder?: (orderedRowIds: string[]) => void
+  /** Override default modifiers (vertical-axis + parent-bounded). */
+  modifiers?: Modifier[]
+}
+
+interface UseDataTableRowDndResult {
+  /** True only after mount AND when `enabled` is true. SSR-safe. */
+  active: boolean
+  /** Stable, ordered list of TanStack `row.id`s for the current page. */
+  rowIds: string[]
+  sensors: SensorDescriptor<SensorOptions>[]
+  modifiers: Modifier[]
+  collisionDetection: CollisionDetection
+  handleDragEnd: (event: DragEndEvent) => void
+}
+
+/**
+ * Encapsulates the dnd-kit wiring for sortable table rows:
+ * sensors, modifiers, collision detection, drag-end → reorder mapping,
+ * and SSR-safe activation (deferred to first effect).
+ */
+export function useDataTableRowDnd<TData>({
+  rows,
+  enabled = false,
+  onRowReorder,
+  modifiers = DEFAULT_DRAG_MODIFIERS,
+}: UseDataTableRowDndOptions<TData>): UseDataTableRowDndResult {
+  const mounted = useMounted()
+
+  const rowIds = React.useMemo(() => rows.map((row) => row.id), [rows])
+
+  const sensors = useSensors(
+    useSensor(MouseSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  )
+
+  const handleDragEnd = React.useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event
+      if (!over || active.id === over.id) return
+
+      const oldIndex = rowIds.indexOf(String(active.id))
+      const newIndex = rowIds.indexOf(String(over.id))
+      if (oldIndex === -1 || newIndex === -1) return
+
+      onRowReorder?.(arrayMove(rowIds, oldIndex, newIndex))
+    },
+    [rowIds, onRowReorder],
+  )
+
+  return {
+    active: enabled && mounted,
+    rowIds,
+    sensors,
+    modifiers,
+    collisionDetection: closestCenter,
+    handleDragEnd,
+  }
+}

--- a/src/hooks/use-data-table-row-dnd.ts
+++ b/src/hooks/use-data-table-row-dnd.ts
@@ -1,45 +1,51 @@
-'use client'
+"use client";
 
-import * as React from 'react'
 import {
-  KeyboardSensor,
-  MouseSensor,
-  TouchSensor,
-  closestCenter,
-  useSensor,
-  useSensors,
   type CollisionDetection,
+  closestCenter,
   type DragEndEvent,
+  KeyboardSensor,
   type Modifier,
+  MouseSensor,
   type SensorDescriptor,
   type SensorOptions,
-} from '@dnd-kit/core'
-import { restrictToParentElement, restrictToVerticalAxis } from '@dnd-kit/modifiers'
-import { arrayMove, sortableKeyboardCoordinates } from '@dnd-kit/sortable'
-import type { Row } from '@tanstack/react-table'
-import { useMounted } from './use-mounted'
+  TouchSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  restrictToParentElement,
+  restrictToVerticalAxis,
+} from "@dnd-kit/modifiers";
+import { arrayMove, sortableKeyboardCoordinates } from "@dnd-kit/sortable";
+import type { Row } from "@tanstack/react-table";
+import * as React from "react";
+import { useMounted } from "./use-mounted";
 
-const DEFAULT_DRAG_MODIFIERS: Modifier[] = [restrictToVerticalAxis, restrictToParentElement]
+const DEFAULT_DRAG_MODIFIERS: Modifier[] = [
+  restrictToVerticalAxis,
+  restrictToParentElement,
+];
 
 interface UseDataTableRowDndOptions<TData> {
-  rows: Row<TData>[]
+  rows: Row<TData>[];
   /** External enable flag (e.g. controlled by a server mutation pending state). */
-  enabled?: boolean
+  enabled?: boolean;
   /** Called with the new visible-row order after a drop. */
-  onRowReorder?: (orderedRowIds: string[]) => void
+  onRowReorder?: (orderedRowIds: string[]) => void;
   /** Override default modifiers (vertical-axis + parent-bounded). */
-  modifiers?: Modifier[]
+  modifiers?: Modifier[];
 }
 
 interface UseDataTableRowDndResult {
   /** True only after mount AND when `enabled` is true. SSR-safe. */
-  active: boolean
+  active: boolean;
   /** Stable, ordered list of TanStack `row.id`s for the current page. */
-  rowIds: string[]
-  sensors: SensorDescriptor<SensorOptions>[]
-  modifiers: Modifier[]
-  collisionDetection: CollisionDetection
-  handleDragEnd: (event: DragEndEvent) => void
+  rowIds: string[];
+  sensors: SensorDescriptor<SensorOptions>[];
+  modifiers: Modifier[];
+  collisionDetection: CollisionDetection;
+  handleDragEnd: (event: DragEndEvent) => void;
 }
 
 /**
@@ -53,29 +59,33 @@ export function useDataTableRowDnd<TData>({
   onRowReorder,
   modifiers = DEFAULT_DRAG_MODIFIERS,
 }: UseDataTableRowDndOptions<TData>): UseDataTableRowDndResult {
-  const mounted = useMounted()
+  const mounted = useMounted();
 
-  const rowIds = React.useMemo(() => rows.map((row) => row.id), [rows])
+  const rowIds = React.useMemo(() => rows.map((row) => row.id), [rows]);
 
   const sensors = useSensors(
     useSensor(MouseSensor, { activationConstraint: { distance: 5 } }),
-    useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 5 } }),
-    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
-  )
+    useSensor(TouchSensor, {
+      activationConstraint: { delay: 200, tolerance: 5 },
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
 
   const handleDragEnd = React.useCallback(
     (event: DragEndEvent) => {
-      const { active, over } = event
-      if (!over || active.id === over.id) return
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
 
-      const oldIndex = rowIds.indexOf(String(active.id))
-      const newIndex = rowIds.indexOf(String(over.id))
-      if (oldIndex === -1 || newIndex === -1) return
+      const oldIndex = rowIds.indexOf(String(active.id));
+      const newIndex = rowIds.indexOf(String(over.id));
+      if (oldIndex === -1 || newIndex === -1) return;
 
-      onRowReorder?.(arrayMove(rowIds, oldIndex, newIndex))
+      onRowReorder?.(arrayMove(rowIds, oldIndex, newIndex));
     },
     [rowIds, onRowReorder],
-  )
+  );
 
   return {
     active: enabled && mounted,
@@ -84,5 +94,5 @@ export function useDataTableRowDnd<TData>({
     modifiers,
     collisionDetection: closestCenter,
     handleDragEnd,
-  }
+  };
 }


### PR DESCRIPTION
- Drag handle column on the tasks table so rows can be reordered without conflicting with cell interactions.
- Data table support for sortable rows, including new DataTableDragHandle and DataTableSortableRow building blocks.
- useDataTableRowDnd hook for DnD Kit–based ordering and state (with cleanup/refinement in the second commit).
- User feedback via a success toast when reorder completes successfully.
- Refactor pass on DataTable, the drag handle, sortable row, and the hook: leaner imports, clearer DnD flow, and more consistent drag styling/context.